### PR TITLE
fix #54 by setting the type property of dependencies

### DIFF
--- a/src/nuget-inspector/NugetResolverHelper.cs
+++ b/src/nuget-inspector/NugetResolverHelper.cs
@@ -56,12 +56,13 @@ public class NugetResolverHelper
             }
 
             if (dependency.name != null)
-                package_tree.AddOrUpdatePackage(id: new BasePackage(name: dependency.name, version: version));
+                package_tree.AddOrUpdatePackage(id: new BasePackage(name: dependency.name, type: dependency.type, version: version));
             return;
         }
 
         var base_package = new BasePackage(
             name: dependency.name!,
+            type: dependency.type,
             version: psmr.Identity.Version.ToNormalizedString());
 
         IEnumerable<NuGet.Packaging.Core.PackageDependency> packages = nugetApi.GetPackageDependenciesForPackage(
@@ -74,7 +75,7 @@ public class NugetResolverHelper
             var resolved_version = package_tree.GetResolvedVersion(name: pkg.Id, range: pkg.VersionRange);
             if (resolved_version != null)
             {
-                var base_pkg = new BasePackage(name: pkg.Id, version: resolved_version);
+                var base_pkg = new BasePackage(name: pkg.Id, type: ComponentType.NuGet, version: resolved_version);
                 dependencies.Add(item: base_pkg);
                 if (Config.TRACE)
                     Console.WriteLine($"        dependencies.Add name: {pkg.Id}, version: {resolved_version}");
@@ -93,6 +94,7 @@ public class NugetResolverHelper
 
                 var dependent_package = new BasePackage(
                     name: psrm.Identity.Id,
+                    type: ComponentType.NuGet,
                     version: psrm.Identity.Version.ToNormalizedString());
 
                 dependencies.Add(item: dependent_package);
@@ -101,6 +103,7 @@ public class NugetResolverHelper
                 {
                     Dependency pd = new(
                         name: pkg.Id,
+                        type: ComponentType.NuGet,
                         version_range: pkg.VersionRange,
                         framework: dependency.framework);
 

--- a/src/nuget-inspector/PackagesConfigHelper.cs
+++ b/src/nuget-inspector/PackagesConfigHelper.cs
@@ -28,7 +28,7 @@ public class PackagesConfigHelper
             foreach (var depPair in pkg.Dependencies)
             {
                 if (depPair.Key == id)
-                result.Add(item: depPair.Value);
+                    result.Add(item: depPair.Value);
             }
         }
 
@@ -39,8 +39,10 @@ public class PackagesConfigHelper
     {
         foreach (var dependency in dependencies)
         {
+            Console.WriteLine( $"ProcessAll() Adding {dependency.type} {dependency.name} to builder" );
             Add(
                 id: dependency.name!,
+                type: dependency.type,
                 name: dependency.name,
                 range: dependency.version_range,
                 framework: dependency.framework);
@@ -60,12 +62,15 @@ public class PackagesConfigHelper
                 {
                     deps.Add(item: new BasePackage(
                         name: ResolutionDatas[key: dep].Name!,
+                        type: ResolutionDatas[key: dep].Type!,
                         version: ResolutionDatas[key: dep].CurrentVersion?.ToNormalizedString()));
                 }
             }
 
             builder.AddOrUpdatePackage(
-                base_package: new BasePackage(name: data.Name!,
+                base_package: new BasePackage(
+                    name: data.Name!,
+                    type: data.Type!,
                     version: data.CurrentVersion?.ToNormalizedString()),
                     dependencies: deps!);
         }
@@ -73,11 +78,12 @@ public class PackagesConfigHelper
         return builder.GetPackageList();
     }
 
-    public void Add(string id, string? name, VersionRange? range, NuGetFramework? framework)
+    public void Add(string id, string type, string? name, VersionRange? range, NuGetFramework? framework)
     {
         id = id.ToLower();
         Resolve(
             id: id,
+            type: type,
             name: name,
             project_target_framework: framework,
             overrideRange: range);
@@ -85,12 +91,14 @@ public class PackagesConfigHelper
 
     private void Resolve(
         string id,
+        string type,
         string? name,
         NuGetFramework? project_target_framework = null,
         VersionRange? overrideRange = null)
     {
         id = id.ToLower();
         ResolutionData data = new();
+        data.Type = type;
         if (ResolutionDatas.ContainsKey(key: id))
         {
             data = ResolutionDatas[key: id];
@@ -138,6 +146,7 @@ public class PackagesConfigHelper
                 data.Dependencies.Add(key: dependency.Id.ToLower(), value: dependency.VersionRange);
                 Resolve(
                     id: dependency.Id.ToLower(),
+                    type: ComponentType.NuGet,
                     name: dependency.Id,
                     project_target_framework: project_target_framework);
             }
@@ -150,5 +159,6 @@ public class PackagesConfigHelper
         public readonly Dictionary<string, VersionRange?> Dependencies = new();
         public VersionRange? ExternalVersionRange;
         public string? Name;
+        public string? Type;
     }
 }

--- a/src/nuget-inspector/PackagesConfigProcessor.cs
+++ b/src/nuget-inspector/PackagesConfigProcessor.cs
@@ -101,6 +101,7 @@ internal class PackagesConfigProcessor : IDependencyProcessor
 
             Dependency dep = new(
                 name: name,
+                type: ComponentType.NuGet,
                 version_range: range,
                 framework: package_framework,
                 is_direct: true,

--- a/src/nuget-inspector/Program.cs
+++ b/src/nuget-inspector/Program.cs
@@ -37,7 +37,7 @@ internal static class Program
     }
 
     /// <summary>
-    /// Return True if there is an warning in the results.
+    /// Return True if there is a warning in the results.
     /// </summary>
     public static bool Has_warnings(OutputFormatJson output)
     {
@@ -52,7 +52,7 @@ internal static class Program
         {
             if (dep.warnings.Any())
                 has_dep_level = true;
-                break;
+            break;
         }
         return has_dep_level;
     }
@@ -73,7 +73,7 @@ internal static class Program
         {
             if (dep.errors.Any())
                 has_dep_level = true;
-                break;
+            break;
         }
         return has_dep_level;
     }
@@ -111,6 +111,7 @@ internal static class Program
 
             Stopwatch deps_timer = Stopwatch.StartNew();
             ScanResult scan_result = scanner.RunScan();
+
             deps_timer.Stop();
 
             Stopwatch meta_timer = Stopwatch.StartNew();
@@ -163,7 +164,7 @@ internal static class Program
                 if (with_warnings)
                     PrintWarnings(scan_result, project_package);
 
-               return ExecutionResult.Succeeded();
+                return ExecutionResult.Succeeded();
             }
             else
             {

--- a/src/nuget-inspector/ProjectFileProcessor.cs
+++ b/src/nuget-inspector/ProjectFileProcessor.cs
@@ -42,6 +42,7 @@ internal class ProjectFileProcessor : IDependencyProcessor
             var rpid = reference.PackageIdentity;
             var dep = new Dependency(
                 name: rpid.Id,
+                type: ComponentType.NuGet,
                 version_range: reference.AllowedVersions ?? new VersionRange(rpid.Version),
                 framework: ProjectFramework,
                 is_direct: true);
@@ -408,6 +409,7 @@ internal class ProjectFileProcessor : IDependencyProcessor
             }
             BasePackage dep = new(
                 name: resolved_dep.Id,
+                type: ComponentType.NuGet,
                 version: resolved_dep.Version.ToString(),
                 framework: ProjectFramework!.GetShortFolderName());
 
@@ -456,6 +458,7 @@ internal class ProjectFileProcessor : IDependencyProcessor
             }
             BasePackage dep = new(
                 name: resolved_dep.Id,
+                type: ComponentType.NuGet,
                 version: resolved_dep.Version.ToString(),
                 framework: ProjectFramework!.GetShortFolderName());
 

--- a/src/nuget-inspector/ProjectJsonProcessor.cs
+++ b/src/nuget-inspector/ProjectJsonProcessor.cs
@@ -27,6 +27,7 @@ internal class ProjectJsonProcessor : IDependencyProcessor
         {
             var bpwd = new BasePackage(
                 name: package.Name,
+                type: ComponentType.NuGet,
                 version: package.LibraryRange.VersionRange.OriginalString
             );
             resolution.Dependencies.Add(item: bpwd);

--- a/src/nuget-inspector/ProjectScanner.cs
+++ b/src/nuget-inspector/ProjectScanner.cs
@@ -88,8 +88,8 @@ internal class ProjectScanner
 
         string project_directory = ScannerOptions.ProjectDirectory;
 
-        // TODO: Also rarer files named packahes.<project name>.congig
-        // See CommandLineUtility.IsValidConfigFileName(Path.GetFileName(path) 
+        // TODO: Also rarer files named packages.<project name>.config
+        // See CommandLineUtility.IsValidConfigFileName(Path.GetFileName(path)
         if (string.IsNullOrWhiteSpace(value: ScannerOptions.PackagesConfigPath))
             ScannerOptions.PackagesConfigPath = combine_paths(project_directory, "packages.config");
 
@@ -152,6 +152,7 @@ internal class ProjectScanner
 
         var project = new BasePackage(
             name: ScannerOptions.ProjectName!,
+            type: ComponentType.Project,
             version: ScannerOptions.ProjectVersion,
             datafile_path: ScannerOptions.ProjectFilePath
         );
@@ -174,11 +175,11 @@ internal class ProjectScanner
         IDependencyProcessor resolver;
 
         // project.assets.json is the gold standard when available
-        // TODO: make the use of lockfiles optional
+        // TODO: make the use of lock files optional
         if (FileExists(path: ScannerOptions.ProjectAssetsJsonPath!))
         {
             if (Config.TRACE)
-                Console.WriteLine($"  Using project-assets.json lockfile at: {ScannerOptions.ProjectAssetsJsonPath}");
+                Console.WriteLine($"  Using project.assets.json lockfile at: {ScannerOptions.ProjectAssetsJsonPath}");
             try
             {
                 resolver = new ProjectAssetsJsonProcessor(projectAssetsJsonPath: ScannerOptions.ProjectAssetsJsonPath!);
@@ -287,7 +288,6 @@ internal class ProjectScanner
         // first we try using MSbuild to read the project
         if (Config.TRACE)
             Console.WriteLine($"  Using project file: {ScannerOptions.ProjectFilePath}");
-
         try
         {
             resolver = new ProjectFileProcessor(


### PR DESCRIPTION
The "type" member in `BasePackage` is never set. It was always `nuget` - therefore every reference was counted as a third-party-reference, including internal project references.

Best regards,
Georg